### PR TITLE
feat: set global color and create 2 components

### DIFF
--- a/components/aggregate/Headline.tsx
+++ b/components/aggregate/Headline.tsx
@@ -1,0 +1,33 @@
+import { Box, Stack, Typography } from '@mui/material';
+
+interface HeadlineProps {
+  title: string
+}
+
+/**
+ * 
+ * TODO
+ * Stack 圓弧樣式
+ */
+
+function Headline(props: HeadlineProps) {
+  const { title } = props
+  return (
+    <Box display='flex' alignItems='center'>
+      <Stack sx={{
+        width: '4px',
+        height: '24px',
+        mr: '12px',
+        bgcolor: 'primary.main'
+      }} />
+      <Typography sx={{
+        fontSize: { sm: '24px' },
+        fontWeight: 700,
+      }}>
+        {title}
+      </Typography>
+    </Box>
+  )
+}
+
+export default Headline

--- a/components/aggregate/SquareCard.tsx
+++ b/components/aggregate/SquareCard.tsx
@@ -1,0 +1,36 @@
+import Box from '@mui/system/Box';
+import { Typography } from '@mui/material';
+
+interface SquareCardProps {
+  title: string,
+  children: React.ReactNode,
+}
+
+
+function SquareCard(props: SquareCardProps) {
+
+  const { title, children } = props
+
+  return (
+    <>
+      <Box
+        width={97}
+        height={97}
+        display="flex"
+        flexDirection="column"
+        justifyContent="space-between"
+        sx={{
+          p: 2,
+          borderRadius: '8px',
+          border: '1px solid ',
+          borderColor: 'primary.light'
+        }}
+      >
+        {children}
+        <Typography sx={{ fontWeight: 700 }}>{title}</Typography>
+      </Box>
+    </>
+  )
+}
+
+export default SquareCard

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.15.3",
     "@mui/material": "^5.15.3",
     "next": "14.0.4",
     "react": "^18",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,40 @@
+import type { AppProps } from 'next/app'
+import CssBaseline from '@mui/material/CssBaseline';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#BF9D7D',
+      light: '#D0B79F',
+      dark: '#7B6651',
+    },
+    error: {
+      main: '#DA3E51',
+      light: '#F5CCD1',
+      dark: '#C22538',
+    },
+    info: {
+      main: '#3BADEF',
+      light: '#B1EFFD',
+      dark: '#1D66AC',
+    },
+    success: {
+      main: '#52DD7E',
+      light: '#BCFBBD',
+      dark: '#299F65',
+    },
+  }
+});
+
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <>
+      <CssBaseline />
+      <ThemeProvider theme={theme}>
+        <Component {...pageProps} />
+      </ThemeProvider>
+    </>
+  );
+}

--- a/pages/aggregate/index.tsx
+++ b/pages/aggregate/index.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { Container, Typography } from '@mui/material';
+import Grid from '@mui/material/Unstable_Grid2';
+import BedIcon from '@mui/icons-material/Bed';
+import SquareCard from '../../components/aggregate/SquareCard';
+import Headline from '../../components/aggregate/Headline';
+
+function Index() {
+
+  return (
+    <Container maxWidth='lg'>
+      <Grid container spacing={2}>
+        <Grid xs={12}>
+          <Grid container spacing={4}>
+            <Grid xs={4}>
+              <Typography variant='h5'>SquareCard</Typography>
+            </Grid>
+            <Grid xs={8}>
+              <SquareCard title='lorem'>
+                <BedIcon color='primary' sx={{ fontSize: 24 }} />
+              </SquareCard>
+            </Grid>
+          </Grid>
+        </Grid>
+        <Grid xs={12}>
+          <Grid container spacing={4}>
+            <Grid xs={4}>
+              <Typography variant='h5'>Headline</Typography>
+            </Grid>
+            <Grid xs={8}>
+              <Headline title='loremlorem' />
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Container>
+  )
+}
+
+export default Index

--- a/yarn.lock
+++ b/yarn.lock
@@ -267,6 +267,13 @@
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.3.tgz#40fc854d7cf5505a182a4e121149dfe21cd277ef"
   integrity sha512-sWeihiVyxdJjpLkp8SHkTy9kt2M/o11M60G1MzwljGL2BXdM3Ktzqv5QaQHdi00y7Y1ulvtI3GOSxP2xU8mQJw==
 
+"@mui/icons-material@^5.15.3":
+  version "5.15.3"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.15.3.tgz#eee07582ea3ad913982b7843ff1612d0fad21278"
+  integrity sha512-7LEs8AnO2Se/XYH+CcJndRsGAE+M8KAExiiQHf0V11poqmPVGcbbY82Ry2IUYf9+rOilCVnWI18ErghZ625BPQ==
+  dependencies:
+    "@babel/runtime" "^7.23.6"
+
 "@mui/material@^5.15.3":
   version "5.15.3"
   resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.15.3.tgz#b77f1ac1275e5bf13b735e8224bdd301aab918c4"


### PR DESCRIPTION
- 使用 CSS reset
- 全域顏色設定（primary, success, info, error）
- 新增 MUI icon 套件
- 新增元件概覽頁面（pages/aggregate/index）
- 新增元件：SquareCard、Headline